### PR TITLE
Add "AllWork" tag to NuclearWork TypeDef

### DIFF
--- a/1.2/Defs/WorkGiverDefs/WorkGivers.xml
+++ b/1.2/Defs/WorkGiverDefs/WorkGivers.xml
@@ -199,6 +199,7 @@
     <workTags>
       <li>ManualDumb</li>
       <li>Hauling</li>
+      <li>AllWork</li>
     </workTags>
   </WorkTypeDef>
 


### PR DESCRIPTION
AllWork is a tag used by Royalty's lazy guests who don't do work to distinguish which types of work are actually work and which are simple things like bedrest that anyone should do.  Adding the AllWork tag will prevent guests who "refuse to do any work" from doing this work.